### PR TITLE
fix: Remove deprecated package attribute from AndroidManifest.xml for…

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.aheaditec.freerasp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
… AGP 8.x compatibility

Removes the deprecated package attribute from AndroidManifest.xml to resolve build failures with Android Gradle Plugin 8.x. The namespace is now properly defined in build.gradle using the namespace property, which is the recommended approach for AGP 8.x and later.

Fixes compatibility issue where the package attribute in AndroidManifest.xml causes build errors in projects using AGP 8.x.

https://github.com/talsec/Free-RASP-Flutter/issues/178
