### PR TITLE
fix: remove stray fi from Push Release Tag step in github-release.yml

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -48,7 +48,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git tag v${{ env.PACKAGE_VERSION }}
           git push origin v${{ env.PACKAGE_VERSION }}
-          fi
 
       - name: GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Removes a stray `fi` on line 51 of `github-release.yml` that caused a shell syntax error (`syntax error near unexpected token 'fi'`)
- The `if/fi` block in the preceding **Download dSYMs** step was already properly closed; the `fi` in the **Push Release Tag** step had no matching `if`

## Test plan
- [ ] Verify the GitHub Actions workflow runs without shell syntax errors on the next trigger

Made with [Cursor](https://cursor.com)