### PR TITLE
Add workflow to verify dSYMs.zip is attached on release PRs

### DIFF
--- a/.github/workflows/check-dsyms.yml
+++ b/.github/workflows/check-dsyms.yml
@@ -1,0 +1,22 @@
+name: Check dSYMs attachment
+
+on:
+  pull_request:
+    types: [labeled, edited]
+
+jobs:
+  check-dsyms:
+    name: Verify dSYMs.zip is attached
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dSYMs.zip in PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$PR_BODY" | grep -qE 'https://[^ )]*dSYMs\.zip'; then
+            echo "dSYMs.zip found in PR description."
+          else
+            echo "::error::dSYMs.zip is not attached in the PR description. Please attach the dSYMs.zip file before merging."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a new `.github/workflows/check-dsyms.yml` workflow
- Triggers on `pull_request` events with types `labeled` and `edited`
- Runs only when the `release` label is present on the PR
- Fails if no `dSYMs.zip` URL is found in the PR description
[dSYMs.zip](https://github.com/user-attachments/files/28827294/dSYMs.zip)

## Test plan
- [ ] Open a PR, apply the `release` label without a `dSYMs.zip` attachment → workflow should fail
- [ ] Edit the PR description to include a `dSYMs.zip` attachment URL → workflow should pass
- [ ] Apply the `release` label when `dSYMs.zip` is already in the description → workflow should pass

Made with [Cursor](https://cursor.com)