### PR TITLE
Fix: Remove global ProGuard flag to support AGP 8.0+

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,1 +1,1 @@
--flattenpackagehierarchy
+# -flattenpackagehierarchy


### PR DESCRIPTION
In Android Gradle Plugin (AGP) 8.0 and above, using global keep options like -flattenpackagehierarchy in a consumer proguard file causes a fatal build error. I have commented this line out to restore AGP 8.0+ compatibility, but please review to ensure this does not break obfuscation routing for older Gradle versions.

Closes #222 