### PR TITLE
release: freeRASP 8.2.2 (Android SDK 19.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.2] - 2026-08-25
+
+- Android SDK version: 19.2.3
+- iOS SDK version: 7.1.2
+
+### Android
+
+#### Fixed
+
+- Fixed the reporting issue in root detection
+- Fixed the reporting issue in hook detection
+
 ## [8.2.1] - 2026-08-10
 
 - Android SDK version: 19.2.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '2.1.0'
-    ext.talsec_version = '19.2.1'
+    ext.talsec_version = '19.2.3'
     repositories {
         google()
         mavenCentral()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: freerasp
 description: Flutter library for improving app security and threat monitoring on Android and iOS mobile devices. Learn more about provided features on the freeRASP's homepage first.
-version: 8.2.1
+version: 8.2.2
 homepage: https://www.talsec.app/freerasp-in-app-protection-security-talsec
 repository: https://github.com/talsec/Free-RASP-Flutter
 


### PR DESCRIPTION
## Summary
- Bumps the Android Talsec SDK dependency from `19.2.1` to `19.2.3`
- Adds a `CHANGELOG.md` entry for `8.2.2` with the Android SDK's fixes: reporting issue in root detection, reporting issue in hook detection
- Bumps package version to `8.2.2` (patch, no plugin API changes — SDK-only fixes)

## Test plan
- [x] `flutter pub get` in `example/` picks up the local `freerasp` package
- [x] Built and ran `example/` on an Android emulator (Pixel 4, API 33) via `flutter run`
- [x] App launches, `Check Rounds Completed` and `Hooks` report `Safe`/green, `Suspicious Apps` dialog renders correctly, no crashes
[dSYMs.zip](https://github.com/user-attachments/files/31454521/dSYMs.zip)


Made with [Cursor](https://cursor.com)